### PR TITLE
Misc. code style, documentation and dependency corrections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,4 @@ before_script:
 - polymer install
 
 script:
-- polymer --version
-- xvfb-run polymer --version
-- xvfb-run polymer test --verbose
+- polymer test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,6 @@ before_script:
 - polymer install
 
 script:
-- xvfb-run polymer test
+- polymer --version
+- xvfb-run polymer --version
+- xvfb-run polymer -v test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ before_script:
 - polymer install
 
 script:
+- node --version
 - polymer test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: node
+node_js: lts/*
 
 # work around a Chrome startup crash issue:
 #   https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356339798
@@ -12,5 +12,4 @@ before_script:
 - polymer install
 
 script:
-- node --version
-- polymer test --verbose
+- polymer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ before_script:
 - polymer install
 
 script:
-- polymer test
+- xvfb-run polymer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ before_script:
 script:
 - polymer --version
 - xvfb-run polymer --version
-- xvfb-run polymer -v test
+- xvfb-run polymer test --verbose

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ these elements shouldn't be relied upon in your CSS declarations.
 
 You can use the following custom CSS properties and mixins:
 
-Custom property                                  | Description                                    | Default
--------------------------------------------------|------------------------------------------------|----------
+Custom property/mixin                         | Description                                    | Default
+----------------------------------------------|------------------------------------------------|----------
 `--spine-expansion-panel-list-item`           | Mixin applied to all list item containers      | `{}`
 `--spine-expansion-panel-list-expanded-item`  | Mixin applied to expanded list item containers | `{}`
 `--spine-expansion-panel-list-expansion-size` | Size by which an expanded item's left/right edges stand out relative to the side edges of collapsed items | `20px`

--- a/bower.json
+++ b/bower.json
@@ -14,9 +14,9 @@
     "paper-styles": "PolymerElements/paper-styles#^2.1.0"
   },
   "devDependencies": {
-    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
     "web-component-tester": "Polymer/web-component-tester#^6.5.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
     "spine-test-helpers": "SpineElements/spine-test-helpers#^0.2.0"
   },
   "resolutions": {

--- a/bower.json
+++ b/bower.json
@@ -11,14 +11,13 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#^2.0.0",
-    "iron-list": "PolymerElements/iron-list#^2.0.14",
-    "paper-styles": "PolymerElements/paper-styles#^2.1.0",
-    "spine-test-helpers": "SpineElements/spine-test-helpers#^0.2.0"
+    "paper-styles": "PolymerElements/paper-styles#^2.1.0"
   },
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",
     "web-component-tester": "Polymer/web-component-tester#^6.5.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
+    "spine-test-helpers": "SpineElements/spine-test-helpers#^0.2.0"
   },
   "resolutions": {
     "polymer": "^2.0.0"

--- a/spine-expansion-panel-list.html
+++ b/spine-expansion-panel-list.html
@@ -60,7 +60,7 @@ Custom property/mixin                         | Description                     
       :host {
         display: block;
 
-        ---shadow-and-separators-color: rgba(0, 0, 0, var(--dark-divider-opacity, 0.12));
+        ---spine-epl-divider-color: rgba(0, 0, 0, var(--dark-divider-opacity, 0.12));
       }
 
       #container ::slotted(.-spine-expansion-panel-list-item) {
@@ -70,17 +70,14 @@ Custom property/mixin                         | Description                     
         color: var(--primary-text-color, #000000);
         padding: 8px 16px;
         cursor: pointer;
+        transition: all 0.2s;
 
         @apply --spine-expansion-panel-list-item;
         overflow: hidden;
       }
 
-      #container ::slotted(.-spine-expansion-panel-list-item) {
-        transition: all 0.2s;
-      }
-
       #container ::slotted(.-spine-expansion-panel-list-item:not([expanded]):not([ends-collapsed-range])) {
-        border-bottom: 1px solid var(---shadow-and-separators-color);
+        border-bottom: 1px solid var(---spine-epl-divider-color);
       }
 
       #container ::slotted(.-spine-expansion-panel-list-item[expanded]) {

--- a/spine-expansion-panel-list.html
+++ b/spine-expansion-panel-list.html
@@ -7,7 +7,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="../paper-styles/shadow.html">
-<link rel="import" href="../iron-list/iron-list.html">
 
 <link rel="import" href="spine-template-stamper.html">
 

--- a/spine-expansion-panel-list.html
+++ b/spine-expansion-panel-list.html
@@ -47,8 +47,8 @@ these elements shouldn't be relied upon in your CSS declarations.
 
 You can use the following custom CSS properties and mixins:
 
-Custom property                                  | Description                                    | Default
--------------------------------------------------|------------------------------------------------|----------
+Custom property/mixin                         | Description                                    | Default
+----------------------------------------------|------------------------------------------------|----------
 `--spine-expansion-panel-list-item`           | Mixin applied to all list item containers      | `{}`
 `--spine-expansion-panel-list-expanded-item`  | Mixin applied to expanded list item containers | `{}`
 `--spine-expansion-panel-list-expansion-size` | Size by which an expanded item's left/right edges stand out relative to the side edges of collapsed items | `20px`

--- a/test/spine-expansion-panel-list_test.html
+++ b/test/spine-expansion-panel-list_test.html
@@ -164,7 +164,7 @@
     });
 
     test('defaults are correct', () => {
-      let expandedItem = list.expandedItem;
+      const expandedItem = list.expandedItem;
       assert.isTrue(expandedItem === null || expandedItem === undefined,
           `expecting expandedItem to be null or undefined by default: ${expandedItem}`);
       assert.equal(list.items, testItems, 'Item assigned are preserved');
@@ -213,7 +213,7 @@
       });
 
       // set an item that is not included in the items list and check the rendered contents
-      let itemNotInTheList = {name: 'Item not in the list', url: 'http://localhost:8080'};
+      const itemNotInTheList = {name: 'Item not in the list', url: 'http://localhost:8080'};
       list.expandedItem = itemNotInTheList;
       assert.equal(list.expandedItem, itemNotInTheList,
           'Checking that expanded item is preserved for "extraneous" items');


### PR DESCRIPTION
Contains the following:
- Dependency corrections:
  - removed the unused `iron-list` dependency;
  - moved `spine-test-helpers` dependency to `devDependencies`, since it's not used at run time.
- Minor CSS declarations refactoring in `spine-expansion-panel-list`.
- Minor code style and documentation corrections.