### PR TITLE
Fix outer click detection logic to handle nested popups properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@ An element that displays an associated array of items as a list of panels showin
 for each item, and allows expanding any item to display a full item view.
 
 You can specify the template for the content that should be displayed for each item using the
-`renderCollapsedItem` property, which should be declared as a function that accepts an item as a
+`renderItem` property, which should be declared as a function that accepts an item as a
  parameter, and returns a respective lit-html `TemplateResult` instance. This function will be
  used for rendering each of the provided items.
 
 A template for an expanded item can be specified using the `renderExpandedItem` property, which
-works the same as `renderCollapsedItem`, but is invoked for rendering an expanded item.
+works the same as `renderItem`, but is invoked for rendering an expanded item.
 
 Example:
 ```
 <spine-expansion-panel-list
     items="${attachments}"
 
-    renderCollapsedItem="${item => html`
+    renderItem="${item => html`
       <div>Name: ${item.name}</div>
       <div>Size: ${item.size}</div>
     `}"

--- a/demo/index.html
+++ b/demo/index.html
@@ -67,7 +67,7 @@
               this.expandedItem = e.detail.expandedItem
             }}"
 
-            renderCollapsedItem="${item => html`
+            renderItem="${item => html`
               <div class="collapsed-item">
                 <div>${item.name}</div>
                 <a href="${item.url}">GitHub page</a>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "web-component",
     "polymer"
   ],
-  "version": "0.3.0",
+  "version": "0.4.0",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/popup-detection.js
+++ b/popup-detection.js
@@ -108,15 +108,11 @@ export function isOuterClickEvent(event, referenceElement) {
     return false;
   }
 
-  const onPopupElement = eventPath.find(el => {
-    if (! (el instanceof Element)) {
-      // can't calculate computed style on non-element nodes, e.g. window
-      return false;
-    }
-    return isPopupElement(el);
+  const popupElement = eventPath.find(eventTarget => {
+    return (eventTarget instanceof Element) && isPopupElement(eventTarget);
   });
-  if (onPopupElement) {
-    const onParentPath = nodeContainsDeep(onPopupElement, referenceElement);
+  if (popupElement) {
+    const onParentPath = nodeContainsDeep(popupElement, referenceElement);
     if (onParentPath) {
       // a popup that contains referenceElement element (outisde click)
       return true;
@@ -126,5 +122,16 @@ export function isOuterClickEvent(event, referenceElement) {
     // invoked from inside of referenceElement
     return false;
   }
+
+  const eventTarget = eventPath[0];
+  const inDocument = findParentElementDeep(eventTarget, n => n === document);
+  // noinspection RedundantIfStatementJS -- retaining a separate if branch for readability
+  if (!inDocument) {
+    // A target element seems to have just been removed from from a document
+    // this is possible in case of OK/Cancel/Close button clicks that close the subdialog before
+    // this event handler. Interpreting this as an inner click in this assumption.
+    return false;
+  }
+
   return true;
 }

--- a/popup-detection.js
+++ b/popup-detection.js
@@ -58,21 +58,22 @@ function nodeContainsDeep(parent, node) {
 const popupFalsePositiveIdentifiers = [];
 
 /**
- * By default all elements whose `position` CSS attribute is either `absolute` or `fixed` is are
- * considered as popup elements (such as dialogs, menus, etc.)
+ * By default all elements whose `position` CSS attribute is either `absolute` or `fixed` are
+ * considered as popup elements (such as dialogs, menus, etc.).
  *
- * In practice, at least `position: absolute` elements can be present not just for implementing
- * popups, but also for a regular application's layout. This function can be used by applications
- * to register their application-specific rules of what absolutely or fixed positioned elements
- * should actually be not considered as popups.
+ * In practice such elements can be present not just for implementing popups, but also for a regular
+ * application's layout, which is hard to formalize since it depends on applications and the
+ * components that they use. This function can be used by applications to register their
+ * application-specific rules of when absolutely or fixed positioned elements should actually not be
+ * considered as popup elements.
  *
- * @param {function(Element):Boolean} isFalsePositive Accepts an element that is considered as an
- *                                                    element that prior analysis have shown to be
- *                                                    a popup element. This function can return
+ * @param {function(Element):Boolean} isFalsePositive A function that accepts an element that is
+ *                                                    considered as a popup element according to a
+ *                                                    prior analysis. This function has to return
  *                                                    `true` to indicate that it "knows" that it is
- *                                                    not a popup element.
+ *                                                    not a popup element, and `false` otherwise.
  */
-export function addFalsePositiveIdentifier(isFalsePositive) {
+export function addFalsePopupDetectionIdentifier(isFalsePositive) {
   popupFalsePositiveIdentifiers.push(isFalsePositive);
 }
 
@@ -86,7 +87,6 @@ function isPopupElement(element) {
       isFalsePositive(element)
   );
   return !notAPopupActually;
-
 }
 
 /**
@@ -99,6 +99,11 @@ function isPopupElement(element) {
  */
 export function isOuterClickEvent(event, referenceElement) {
   const eventPath = event.composedPath();
+  const eventTarget = eventPath[0];
+  if (eventTarget === referenceElement) {
+    return false;
+  }
+
   const inSubtree = eventPath.some(eventTarget =>
       eventTarget !== referenceElement &&
       eventTarget instanceof Node &&
@@ -123,7 +128,6 @@ export function isOuterClickEvent(event, referenceElement) {
     return false;
   }
 
-  const eventTarget = eventPath[0];
   const inDocument = findParentElementDeep(eventTarget, n => n === document);
   // noinspection RedundantIfStatementJS -- retaining a separate if branch for readability
   if (!inDocument) {

--- a/popup-detection.js
+++ b/popup-detection.js
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2000-2018 TeamDev. All rights reserved.
+ * TeamDev PROPRIETARY and CONFIDENTIAL.
+ * Use is subject to license terms.
+ */
+
+
+/**
+ * A "parent" node in a combined hierarchy of light and shadow DOMs.
+ *
+ * @param {Node} node  a node whose parent should be returned
+ * @returns {Node} an immediate parent of the specified `node`, or a host element if the `node`
+ *                 represents a shadow root
+ */
+function getImmediateParentDeep(node) {
+  if (node.parentNode) {
+    return node.parentNode;
+  }
+  if (node instanceof ShadowRoot) {
+    return node.host;
+  }
+  return null;
+}
+
+/**
+ * Finds the nearest parent that satisfies the specified `condition` in a combined hierarchy of
+ * light and shadow DOMs.
+ *
+ * @param {Node} node
+ * @param {function(Node):Boolean} condition
+ * @returns {Node}
+ */
+function findParentElementDeep(node, condition) {
+  while(true) {
+    node = this.getImmediateParentDeep(node);
+    if (!node) {
+      return null;
+    }
+    if (condition(node)) {
+      return node;
+    }
+  }
+}
+
+/**
+ * @param {Node} parent
+ * @param {Node} node
+ * @returns {Boolean} `true` if `parent` contains `element` "deeply" (e.g. any light or shadow DOM
+ *                    nested under this element on any level
+ */
+function nodeContainsDeep(parent, node) {
+  return !!findParentElementDeep(node, p => p === parent);
+}
+
+const popupFalsePositiveIdentifiers = [];
+
+/**
+ * By default all elements whose `position` CSS attribute is either `absolute` or `fixed` is are
+ * considered as popup elements (such as dialogs, menus, etc.)
+ *
+ * In practice, at least `position: absolute` elements can be present not just for implementing
+ * popups, but also for a regular application's layout. This function can be used by applications
+ * to register their application-specific rules of what absolutely or fixed positioned elements
+ * should actually be not considered as popups.
+ *
+ * @param {function(Element):Boolean} isFalsePositive Accepts an element that is considered as an
+ *                                                    element that prior analysis have shown to be
+ *                                                    a popup element. This function can return
+ *                                                    `true` to indicate that it "knows" that it is
+ *                                                    not a popup element.
+ */
+export function addFalsePositiveIdentifier(isFalsePositive) {
+  popupFalsePositiveIdentifiers.push(isFalsePositive);
+}
+
+function isPopupElement(element) {
+  const position = getComputedStyle(element)['position'];
+  const elementCanBeAPopup = position === 'absolute' || position === 'fixed';
+  if (!elementCanBeAPopup) {
+    return false;
+  }
+  const notAPopupActually = popupFalsePositiveIdentifiers.some(isFalsePositive =>
+      isFalsePositive(element)
+  );
+  return !notAPopupActually;
+
+}
+
+/**
+ * Checks whether the passed event occurred inside of the `referenceElement` or outside of it.
+ *
+ * @param {Event} event
+ * @param {Element} referenceElement
+ * @returns {boolean} `true`, if an event is considered as being performed outside of the provided
+ *                     `referenceElement`, and `false` otherwise
+ */
+export function isOuterClickEvent(event, referenceElement) {
+  const eventPath = event.composedPath();
+  const inSubtree = eventPath.some(eventTarget =>
+      eventTarget !== referenceElement &&
+      eventTarget instanceof Node &&
+      referenceElement.contains(eventTarget)
+  );
+  if (inSubtree) {
+    return false;
+  }
+
+  const onPopupElement = eventPath.find(el => {
+    if (! (el instanceof Element)) {
+      // can't calculate computed style on non-element nodes, e.g. window
+      return false;
+    }
+    return isPopupElement(el);
+  });
+  if (onPopupElement) {
+    const onParentPath = nodeContainsDeep(onPopupElement, referenceElement);
+    if (onParentPath) {
+      // a popup that contains referenceElement element (outisde click)
+      return true;
+    }
+    // all other popups are treated as popups nested in referenceElement, which are structurally
+    // outside of referenceElement's nested DOM to solve stacking context issues, but are logically
+    // invoked from inside of referenceElement
+    return false;
+  }
+  return true;
+}

--- a/popup-detection.js
+++ b/popup-detection.js
@@ -32,7 +32,7 @@ function getImmediateParentDeep(node) {
  */
 function findParentElementDeep(node, condition) {
   while(true) {
-    node = this.getImmediateParentDeep(node);
+    node = getImmediateParentDeep(node);
     if (!node) {
       return null;
     }
@@ -52,6 +52,9 @@ function nodeContainsDeep(parent, node) {
   return !!findParentElementDeep(node, p => p === parent);
 }
 
+/**
+ * @type {Array.<function(Element):Boolean>}
+ */
 const popupFalsePositiveIdentifiers = [];
 
 /**

--- a/spine-expansion-panel-list.js
+++ b/spine-expansion-panel-list.js
@@ -6,7 +6,7 @@
 
 import {render} from 'lit-html/lit-html.js';
 import {LitElement, html} from '@polymer/lit-element';
-import { microTask } from '@polymer/polymer/lib/utils/async.js';
+import {microTask} from '@polymer/polymer/lib/utils/async.js';
 import '@polymer/paper-styles/shadow.js';
 import {isOuterClickEvent} from './popup-detection.js';
 

--- a/spine-expansion-panel-list.js
+++ b/spine-expansion-panel-list.js
@@ -110,6 +110,7 @@ class SpineFloatingExpansionList extends LitElement {
         }
   
         #container ::slotted(.-spine-expansion-panel-list--item) {
+          position: relative;
           margin: 0 var(--spine-expansion-panel-list-expansion-size, 20px);
           @apply --shadow-elevation-2dp;
           background: var(--primary-background-color, #ffffff);
@@ -134,6 +135,31 @@ class SpineFloatingExpansionList extends LitElement {
   
           @apply --spine-expansion-panel-list-expanded-item;
         }
+        
+        #container ::slotted(.-spine-expansion-panel-list--item:focus) {
+          outline: none;
+        }
+        
+        #container ::slotted(.-spine-expansion-panel-list--item:not([expanded]):focus)::before {
+          content: '';
+          background: #53c297;
+          position: absolute;
+          left: 0;
+          top: 0;
+          bottom: 0;
+          width: 3px;
+        }
+
+        #container ::slotted(.-spine-expansion-panel-list--item:not([expanded]):focus)::after {
+          content: '';
+          background: #53c297;
+          position: absolute;
+          left: 0;
+          top: 0;
+          bottom: 0;
+          right: 0;
+          opacity: 0.05;
+        }
       </style>
   
       <div id="container">
@@ -155,10 +181,12 @@ class SpineFloatingExpansionList extends LitElement {
   _renderLightDOM({items, expandedItem, renderItem, renderExpandedItem}) {
     return html`${
         items.map(item => html`
-        <div class="-spine-expansion-panel-list--item" 
+        <div class="-spine-expansion-panel-list--item"
+             tabindex="0"
              expanded?="${(item === expandedItem)}" 
              ends-collapsed-range?="${this._getItemEndsCollapsedRange(item)}" 
-             on-click="${e => this._handleItemClick(item)}">
+             on-click="${e => this._handleItemClick(item)}"
+             on-keydown="${e => this._handleItemKeydown(item, e)}">
           <div class="-spine-expansion-panel-list--item-content">
             <!--
               The "overflow: hidden" style is added below to prevent collapsing the custom
@@ -173,7 +201,7 @@ class SpineFloatingExpansionList extends LitElement {
               https://developers.google.com/web/fundamentals/web-components/shadowdom#stylinglightdom
             -->
             <div style="overflow: hidden">${
-            item !== expandedItem || !this.renderExpandedItem
+              item !== expandedItem || !this.renderExpandedItem
                 ? renderItem(item, item === expandedItem)
                 : renderExpandedItem(item)
             }</div>
@@ -365,6 +393,22 @@ class SpineFloatingExpansionList extends LitElement {
   _handleDocumentClick(event) {
     if (isOuterClickEvent(event, this)) {
       this._setExpandedItem(null);
+    }
+  }
+
+  _handleItemKeydown(item, event) {
+    const itemElement = this._getItemElement(item);
+    const onSubelement = event.target !== itemElement;
+
+    switch (event.keyCode) {
+      case 13: // Enter
+        if (!onSubelement) {
+          this._setExpandedItem(item);
+        }
+        break;
+      case 27: // Esc
+        this._setExpandedItem(null);
+        break;
     }
   }
 }

--- a/spine-expansion-panel-list.js
+++ b/spine-expansion-panel-list.js
@@ -6,6 +6,7 @@
 
 import {render} from 'lit-html/lit-html.js';
 import {LitElement, html} from '@polymer/lit-element';
+import { microTask } from '@polymer/polymer/lib/utils/async.js';
 import '@polymer/paper-styles/shadow.js';
 
 /**
@@ -278,18 +279,21 @@ class SpineFloatingExpansionList extends LitElement {
 
     renderUpdatedUI();
 
-    // start the height transition animation by setting height to match the updated (expanded or
-    // collapsed) content height
-    itemHeightsToAnimate.forEach(setItemHeightByContentHeight);
+    // wait a microtask delay to let a component update a UI if it is not rendered immediately
+    microTask.run(() => {
+      // start the height transition animation by setting height to match the updated (expanded or
+      // collapsed) content height
+      itemHeightsToAnimate.forEach(setItemHeightByContentHeight);
 
-    // when animation completes, reset item heights from fixed values back to 'auto' for any
-    // subsequent height changes that might occur dynamically are not ignored (e.g. if item content
-    // changes dynamically after this)
-    const transitionDuration =
-        this.constructor.__getElementTransitionDuration(itemHeightsToAnimate[0]);
-    setTimeout(() => {
-      itemHeightsToAnimate.forEach(setItemHeightAuto);
-    }, transitionDuration);
+      // when animation completes, reset item heights from fixed values back to 'auto' for any
+      // subsequent height changes that might occur dynamically are not ignored (e.g. if item content
+      // changes dynamically after this)
+      const transitionDuration =
+          this.constructor.__getElementTransitionDuration(itemHeightsToAnimate[0]);
+      setTimeout(() => {
+        itemHeightsToAnimate.forEach(setItemHeightAuto);
+      }, transitionDuration);
+    });
   }
 
   /**

--- a/spine-expansion-panel-list.js
+++ b/spine-expansion-panel-list.js
@@ -8,6 +8,7 @@ import {render} from 'lit-html/lit-html.js';
 import {LitElement, html} from '@polymer/lit-element';
 import { microTask } from '@polymer/polymer/lib/utils/async.js';
 import '@polymer/paper-styles/shadow.js';
+import {isOuterClickEvent} from './popup-detection.js';
 
 /**
  * An element that displays an associated array of items as a list of panels showing a summary view
@@ -362,13 +363,9 @@ class SpineFloatingExpansionList extends LitElement {
   }
 
   _handleDocumentClick(event) {
-    if (event.composedPath().some(el =>
-        el !== this && el instanceof Node && this.contains(el)
-    )) {
-      // one of the items was clicked, no auto collapsing is required
-      return;
+    if (isOuterClickEvent(event, this)) {
+      this._setExpandedItem(null);
     }
-    this._setExpandedItem(null);
   }
 }
 

--- a/spine-expansion-panel-list.js
+++ b/spine-expansion-panel-list.js
@@ -14,19 +14,19 @@ import '@polymer/paper-styles/shadow.js';
  * for each item, and allows expanding any item to display a full item view.
  *
  * You can specify the template for the content that should be displayed for each item using the
- * `renderCollapsedItem` property, which should be declared as a function that accepts an item as a
+ * `renderItem` property, which should be declared as a function that accepts an item as a
  *  parameter, and returns a respective lit-html `TemplateResult` instance. This function will be
  *  used for rendering each of the provided items.
  *
  * A template for an expanded item can be specified using the `renderExpandedItem` property, which
- * works the same as `renderCollapsedItem`, but is invoked for rendering an expanded item.
+ * works the same as `renderItem`, but is invoked for rendering an expanded item.
  *
  * Example:
  * ```
  * <spine-expansion-panel-list
  *     items="${attachments}"
  *
- *     renderCollapsedItem="${item => html`
+ *     renderItem="${item => html`
  *       <div>Name: ${item.name}</div>
  *       <div>Size: ${item.size}</div>
  *     `}"
@@ -66,7 +66,7 @@ class SpineFloatingExpansionList extends LitElement {
        * An array of objects (or values of other type) that identify the list of items being
        * rendered by this component. Each item in this array is used as a model that will be passed
        * to an item template rendering function when a corresponding item is rendered. See the
-       * `renderCollapsedItem` and `renderExpandedItem` properties.
+       * `renderItem` and `renderExpandedItem` properties.
        *
        * A component's user is free to choose any type and form of the item objects provided in this
        * array.
@@ -82,7 +82,7 @@ class SpineFloatingExpansionList extends LitElement {
        * returns the lit-html's `TemplateResult` that corresponds to the content that should be
        * rendered for this item.
        */
-      renderCollapsedItem: Function,
+      renderItem: Function,
       /**
        * A function for rendering expanded items. It receives an item from the `items` array, and
        * returns the lit-html's `TemplateResult` that corresponds to the content that should be
@@ -145,13 +145,13 @@ class SpineFloatingExpansionList extends LitElement {
    * Similar to `_render`, but renders content that should be placed in an element's light DOM.
    *
    * The item elements, with their respective custom content templates that have been provided via
-   * `renderCollapsedItem` and `renderExpandedItem` properties, have to be rendered into element's
+   * `renderItem` and `renderExpandedItem` properties, have to be rendered into element's
    * light DOM and not shadow DOM.
    *
    * This is needed for their style to be customizable with CSS declarations present in the
    * context where the `spine-expansion-panel-list` element is used.
    */
-  _renderLightDOM({items, expandedItem, renderCollapsedItem, renderExpandedItem}) {
+  _renderLightDOM({items, expandedItem, renderItem, renderExpandedItem}) {
     return html`${
         items.map(item => html`
         <div class="-spine-expansion-panel-list--item" 
@@ -173,7 +173,7 @@ class SpineFloatingExpansionList extends LitElement {
             -->
             <div style="overflow: hidden">${
             item !== expandedItem || !this.renderExpandedItem
-                ? renderCollapsedItem(item)
+                ? renderItem(item, item === expandedItem)
                 : renderExpandedItem(item)
             }</div>
           </div>
@@ -190,9 +190,9 @@ class SpineFloatingExpansionList extends LitElement {
     super._applyRender(result, node);
 
     // render light DOM tree
-    const {items, expandedItem, renderCollapsedItem, renderExpandedItem} = this;
+    const {items, expandedItem, renderItem, renderExpandedItem} = this;
     const lightDOMTemplateResult = this._renderLightDOM(
-        {items, expandedItem, renderCollapsedItem, renderExpandedItem}
+        {items, expandedItem, renderItem, renderExpandedItem}
     );
     render(lightDOMTemplateResult, this);
   }

--- a/test/popup-detection_test.html
+++ b/test/popup-detection_test.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<!--
+  ~ Copyright (c) 2000-2018 TeamDev. All rights reserved.
+  ~ TeamDev PROPRIETARY and CONFIDENTIAL.
+  ~ Use is subject to license terms.
+-->
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Popup detection test</title>
+
+  <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+  <script src="../node_modules/wct-browser-legacy/browser.js"></script>
+  <style>
+    .bordered {
+      border: 1px solid silver;
+    }
+    #reference-element {
+      width: 300px;
+      height: 300px;
+      position: relative;
+      border: 2px solid black;
+    }
+    #ordinary-nested-content, #outer-content {
+      width: 100px;
+      height: 100px;
+    }
+    #nested-popup-absolute, #nested-popup-fixed,
+    #outer-absolute-content-not-a-popup,
+    #outer-fixed-content-not-a-popup {
+      width: 100px;
+      height: 50px;
+    }
+    #nested-popup-absolute {
+      position: absolute;
+      left: 50px;
+      top: 150px;
+    }
+    #nested-popup-fixed {
+      position: fixed;
+      left: 150px;
+      top: 250px;
+    }
+    #outer-absolute-content-not-a-popup {
+      position: absolute;
+      margin-top: 10px;
+    }
+    #outer-fixed-content-not-a-popup {
+      position: fixed;
+      left: 150px;
+      top: 450px;
+    }
+  </style>
+</head>
+<body>
+
+<test-fixture id="test-setup">
+  <template>
+    <div id="outer-container" class="bordered">
+      <div id="reference-element" class="bordered">
+        <div id="ordinary-nested-content" class="bordered"><button>ordinary-nested-content</button></div>
+        <div id="nested-popup-absolute" class="bordered"><button>nested-popup-absolute</button></div>
+        <div id="nested-popup-fixed" class="bordered"><button>nested-popup-fixed</button></div>
+        <button>reference-element</button>
+      </div>
+      <div id="outer-content" class="bordered"><button>outer-content</button></div>
+      <div id="outer-absolute-content-not-a-popup" class="bordered">
+        <button>outer-absolute-content-not-a-popup</button>
+      </div>
+      <div id="outer-fixed-content-not-a-popup" class="bordered">
+        <button>outer-fixed-content-not-a-popup</button>
+      </div>
+      <button>outer-container</button>
+    </div>
+  </template>
+</test-fixture>
+
+<script type="module">
+  import {isOuterClickEvent, addFalsePopupDetectionIdentifier} from '../popup-detection.js';
+
+  addFalsePopupDetectionIdentifier(el => {
+    return el.id === 'outer-absolute-content-not-a-popup' ||
+        el.id === 'outer-fixed-content-not-a-popup';
+  });
+
+  suite('popup-detection test', function() {
+    let outerContainer;
+    let referenceElement;
+    setup(() => {
+      outerContainer = fixture('test-setup');
+      referenceElement = document.querySelector('#reference-element');
+    });
+
+    function testOuterClick(clickedElementId, expectedAsOuterClick) {
+      test(`Clicking on ${clickedElementId}`, () => {
+        let outerClickDetected;
+        const handleClick = event => {
+          outerClickDetected = isOuterClickEvent(event, referenceElement);
+        };
+        document.addEventListener('click', handleClick);
+        try {
+          const testWithElement = (elementSelector, clicker) => {
+            const element = document.querySelector(elementSelector);
+            if (!element) {
+              throw Error(`Couldn't find element ${elementSelector}`);
+            }
+            // noinspection UnnecessaryLocalVariableJS
+            const unsetValue = {};
+            outerClickDetected = unsetValue;
+            clicker(element);
+            assert.equal(outerClickDetected, expectedAsOuterClick,
+                `Checking isOuterClickEvent for element ${elementSelector}`);
+          };
+
+          testWithElement(`#${clickedElementId}`, element => {
+            element.dispatchEvent(new MouseEvent('click', {
+              bubbles: true,
+              cancellable: true,
+              composed: true
+            }));
+          });
+
+          testWithElement(`#${clickedElementId} > button`, element => {
+            element.click();
+          });
+        } finally {
+          document.removeEventListener('click', handleClick);
+        }
+      });
+    }
+
+    testOuterClick('reference-element', false);
+    testOuterClick('ordinary-nested-content', false);
+    testOuterClick('nested-popup-absolute', false);
+    testOuterClick('nested-popup-fixed', false);
+    testOuterClick('outer-container', true);
+    testOuterClick('outer-content', true);
+    testOuterClick('outer-absolute-content-not-a-popup', true);
+    testOuterClick('outer-fixed-content-not-a-popup', true);
+  });
+</script>
+</body>
+</html>

--- a/test/spine-expansion-panel-list_test.html
+++ b/test/spine-expansion-panel-list_test.html
@@ -48,7 +48,7 @@
         <div id="list-container">
           <spine-expansion-panel-list id="list"
             items="${this.items}"
-            renderCollapsedItem="${item => html`
+            renderItem="${item => html`
               <div class="collapsed-test-item">
                 <div>${item.name}</div>
                 <a href="${item.url}">GitHub page</a>


### PR DESCRIPTION
Besides the fix, the PR contains the following:
- Changed the behavior of `renderCollapsedItem`:
  - It now accepts an additional `expanded: Boolean` parameter.
  - It has been renamed to `renderItem`.
  - The `renderExpandedItem` property has been made optional. It is possible to use `renderItem=${(item, expanded) => ...}` instead whenever it is more convenient to render both states in one renderer.
- Fixed improper height animation on expanding/collapsing an item if the rendering of a new state is not performed synchronously.