### PR TITLE
Keyboard behavior amendments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ addons:
   chrome: stable
 before_script:
   - npm install -g polymer-cli
-  - npm --version
 script: xvfb-run polymer test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ addons:
   chrome: stable
 before_script:
   - npm install -g polymer-cli
+  - npm --version
 script: xvfb-run polymer test
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ An element that displays an associated array of items as a list of panels showin
 for each item, and allows expanding any item to display a full item view.
 
 You can specify the template for the content that should be displayed for each item using the
-`renderItem` property, which should be declared as a function that accepts two arguments: an
- item, and a boolean `expanded` value, and returns a respective lit-html `TemplateResult`
- instance. This function will be used for rendering each of the provided items.
+`renderItem` property, which should be declared as a function that accepts an item, and its state
+parameters such as `expanded` and `focused` values, and returns a respective lit-html
+`TemplateResult` instance. This function will be used for rendering each of the provided items.
 
-A template for an expanded item can be specified using the `renderExpandedItem` property, which
-works the same as `renderItem`, but is invoked for rendering an expanded item. If this attribute
-is specified, the function specified with `renderItem` will be used only for rendering collapsed
-items.
+A template for an expanded item can alternatively be specified separately using the
+`renderExpandedItem` property, which works similarly to `renderItem`, but is invoked for
+rendering an expanded item. If this attribute is specified, the function specified with
+`renderItem` will be used only for rendering collapsed items.
 
 Example:
 ```
@@ -35,7 +35,7 @@ Example:
 A user can expand and collapse items either using a mouse or a keyboard (by pressing Tab to focus
 a respective item, Enter to expand it, and Esc to collapse it).
 
-It is also possible to make certian portion(s) of an expanded item's layout as active areas that
+It is also possible to make certain portion(s) of an expanded item's layout as active areas that
 can be clicked to collapse an item. To do this, add the `spine-epl-expansion-toggle` class to the
 respective element in an expanded layout.
 
@@ -58,7 +58,7 @@ Custom property/mixin                         | Description                     
 `--spine-expansion-panel-list-item`           | Mixin applied to all list item containers      | `{}`
 `--spine-expansion-panel-list-expanded-item`  | Mixin applied to expanded list item containers | `{}`
 `--spine-expansion-panel-list-expansion-size` | Size by which an expanded item's left/right edges stand out relative to the side edges of collapsed items | `20px`
-`--spine-expansion-panel-list-focus-color`    | A color for displaying a focus bar and a semi-transparent overlay for a focused item | `#53c297`
+`--spine-expansion-panel-list-focus-color`    | A color for displaying a focus bar and a semi-transparent overlay for a focused item | `var(--accent-color, #ff4081)`
 `--spine-expansion-panel-list-item-focus-bar` | Mixin for a focus bar for a focused item (displayed on the left item's side by default) | `{}`
 `--spine-expansion-panel-list-item-focus-overlay` | Mixin for an semi-transparent overlay that is displayed over a focused item | `{}`
 `--shadow-elevation-2dp`                      | Mixin that specifies a shadow displayed for collapsed items by default | (see @polymer/paper-styles/shadow.js)

--- a/demo/index.html
+++ b/demo/index.html
@@ -54,10 +54,17 @@
           }
           .expanded-item a {
             font-size: 15px;
+            flex: 1 1 auto;
           }
           h2 {
             cursor: pointer;
             border-bottom: 1px solid silver;
+          }
+          .collapsed-item .item-menu {
+            display: inline-block;
+            width: 100px;
+            flex: none;
+            text-align: right;
           }
         </style>
 
@@ -71,14 +78,17 @@
               this.expandedItem = e.detail.expandedItem
             }}"
 
-            renderItem="${item => html`
+            renderItem="${(item, expanded, focused) => html`
               <div class="collapsed-item">
                 <div>${item.name}</div>
                 <a href="${item.url}">GitHub page</a>
+                <div class="item-menu">${focused ? html`
+                  [item menu]
+                ` : ''}</div>
               </div>
             `}"
 
-            renderExpandedItem="${item => html`
+            renderExpandedItem="${(item, focused) => html`
               <div class="expanded-item">
                 <h2 class$="${expansionToggleClassName}">${item.name}</h2>
                 <a href="${item.url}">GitHub page</a>

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,7 +30,7 @@
         {name: 'spine-item-elements', url: 'https://github.com/SpineElements/spine-item-elements'},
         {name: 'spine-color-picker', url: 'https://github.com/SpineElements/spine-color-picker'},
         {name: 'spine-contraster', url: 'https://github.com/SpineElements/spine-contraster'},
-        {name: 'spine-icon-button', url: 'https://github.com/SpxineElements/spine-icon-button'},
+        {name: 'spine-icon-button', url: 'https://github.com/SpineElements/spine-icon-button'},
         {name: 'spine-button', url: 'https://github.com/SpineElements/spine-button'},
         {name: 'spine-context-menu', url: 'https://github.com/SpineElements/spine-context-menu'},
         {name: 'spine-social-button', url: 'https://github.com/SpineElements/spine-social-button'},

--- a/demo/index.html
+++ b/demo/index.html
@@ -49,6 +49,12 @@
           .collapsed-item div {
             flex: 1 1 auto;
           }
+          .collapsed-item .item-focus-indicator {
+            display: inline-block;
+            width: 100px;
+            flex: none;
+            text-align: right;
+          }
           .expanded-item {
             padding: 0 0 16px;
           }
@@ -59,12 +65,6 @@
           h2 {
             cursor: pointer;
             border-bottom: 1px solid silver;
-          }
-          .collapsed-item .item-menu {
-            display: inline-block;
-            width: 100px;
-            flex: none;
-            text-align: right;
           }
         </style>
 
@@ -82,8 +82,8 @@
               <div class="collapsed-item">
                 <div>${item.name}</div>
                 <a href="${item.url}">GitHub page</a>
-                <div class="item-menu">${focused ? html`
-                  [item menu]
+                <div class="item-focus-indicator">${focused ? html`
+                  [focused]
                 ` : ''}</div>
               </div>
             `}"

--- a/demo/index.html
+++ b/demo/index.html
@@ -30,7 +30,7 @@
         {name: 'spine-item-elements', url: 'https://github.com/SpineElements/spine-item-elements'},
         {name: 'spine-color-picker', url: 'https://github.com/SpineElements/spine-color-picker'},
         {name: 'spine-contraster', url: 'https://github.com/SpineElements/spine-contraster'},
-        {name: 'spine-icon-button', url: 'https://github.com/SpineElements/spine-icon-button'},
+        {name: 'spine-icon-button', url: 'https://github.com/SpxineElements/spine-icon-button'},
         {name: 'spine-button', url: 'https://github.com/SpineElements/spine-button'},
         {name: 'spine-context-menu', url: 'https://github.com/SpineElements/spine-context-menu'},
         {name: 'spine-social-button', url: 'https://github.com/SpineElements/spine-social-button'},
@@ -43,6 +43,15 @@
     _render({expandedItem}) {
       return html`
         <style>
+          spine-expansion-panel-list {
+            --spine-expansion-panel-list-expanded-item: {
+              padding: 0;
+            }
+          }
+          h2 {
+            margin: 0;
+            padding: 16px;
+          }
           .collapsed-item {
             display: flex;
           }
@@ -56,11 +65,13 @@
             text-align: right;
           }
           .expanded-item {
-            padding: 0 0 16px;
+            padding: 0;
           }
           .expanded-item a {
-            font-size: 15px;
             flex: 1 1 auto;
+            display: inline-block;
+            margin: 16px;
+            font-size: 15px;
           }
           h2 {
             cursor: pointer;

--- a/dom-helpers.js
+++ b/dom-helpers.js
@@ -33,7 +33,7 @@ function getImmediateParentDeep(node) {
  * @returns {Node}
  */
 export function findParentElementDeep(node, condition, upToNode) {
-  for(let currentParent = getImmediateParentDeep(node);
+  for(let currentParent = node;
       currentParent;
       currentParent = currentParent !== upToNode
           ? getImmediateParentDeep(currentParent)
@@ -52,7 +52,7 @@ export function findParentElementDeep(node, condition, upToNode) {
  *                    nested under this element on any level
  */
 function nodeContainsDeep(parent, node) {
-  return !!findParentElementDeep(node, p => p === parent);
+  return parent !== node && !!findParentElementDeep(node, p => p === parent);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "web-component",
     "polymer"
   ],
-  "version": "0.4.1",
+  "version": "0.4.2",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/spine-expansion-panel-list.js
+++ b/spine-expansion-panel-list.js
@@ -26,14 +26,14 @@ const listItemClassName = '-spine-expansion-panel-list--item';
  * for each item, and allows expanding any item to display a full item view.
  *
  * You can specify the template for the content that should be displayed for each item using the
- * `renderItem` property, which should be declared as a function that accepts two arguments: an
- *  item, and a boolean `expanded` value, and returns a respective lit-html `TemplateResult`
- *  instance. This function will be used for rendering each of the provided items.
+ * `renderItem` property, which should be declared as a function that accepts an item, and its state
+ * parameters such as `expanded` and `focused` values, and returns a respective lit-html
+ * `TemplateResult` instance. This function will be used for rendering each of the provided items.
  *
- * A template for an expanded item can be specified using the `renderExpandedItem` property, which
- * works the same as `renderItem`, but is invoked for rendering an expanded item. If this attribute
- * is specified, the function specified with `renderItem` will be used only for rendering collapsed
- * items.
+ * A template for an expanded item can alternatively be specified separately using the
+ * `renderExpandedItem` property, which works similarly to `renderItem`, but is invoked for
+ * rendering an expanded item. If this attribute is specified, the function specified with
+ * `renderItem` will be used only for rendering collapsed items.
  *
  * Example:
  * ```
@@ -57,7 +57,7 @@ const listItemClassName = '-spine-expansion-panel-list--item';
  * A user can expand and collapse items either using a mouse or a keyboard (by pressing Tab to focus
  * a respective item, Enter to expand it, and Esc to collapse it).
  *
- * It is also possible to make certian portion(s) of an expanded item's layout as active areas that
+ * It is also possible to make certain portion(s) of an expanded item's layout as active areas that
  * can be clicked to collapse an item. To do this, add the `spine-epl-expansion-toggle` class to the
  * respective element in an expanded layout.
  *
@@ -107,8 +107,10 @@ class SpineFloatingExpansionList extends LitElement {
       expandedItem: Object,
       /**
        * A function for rendering collapsed items. It receives two parameters:
-       *  - {*}       item     — an item's value from the `items` array;
+       *  - {*}       item     — an item's value from the `items` array.
        *  - {Boolean} expanded — set to `true` if the item is expanded, and `false` if collapsed.
+       *  - {Boolean} focused  — set to `true` if the item is focused (including when any of its
+       *                         subelements are focused).
        *
        * This function should returns the lit-html's `TemplateResult` that corresponds to the
        * content that should be rendered for this item.
@@ -123,11 +125,17 @@ class SpineFloatingExpansionList extends LitElement {
        *
        * It receives one argument:
        *  - {*} item — an item's value from the `items` array.
+       *  - {Boolean} focused  — set to `true` if the item is focused (including when any of its
+       *                         subelements are focused).
        *
        * Returns the lit-html's `TemplateResult` that corresponds to the content that should be
        * rendered for this item in its expanded state.
        */
       renderExpandedItem: Function,
+      /**
+       * Contains item value of a currently focused item. Item is considered focused here when
+       * either its main element is focused, or any of its subelements are focused.
+       */
       _focusedItem: Element
     }
   }

--- a/spine-expansion-panel-list.js
+++ b/spine-expansion-panel-list.js
@@ -465,12 +465,22 @@ class SpineFloatingExpansionList extends LitElement {
 
   _handleAnyFocus(event) {
     this._focusedItem = this._getItemByEvent(event);
+    if (this._focusedItemResetTimeoutId != null) {
+      clearTimeout(this._focusedItemResetTimeoutId);
+      this._focusedItemResetTimeoutId = null;
+    }
   }
 
   _handleAnyBlur(event) {
     const itemByEvent = this._getItemByEvent(event);
     if (this._focusedItem === itemByEvent) {
-      this._focusedItem = null;
+      this._focusedItemResetTimeoutId = setTimeout(() => {
+        // reset the focused item (and rerender the view accordingly) after an asynchronous delay
+        // in order to avoid the intermediate removal of the focused state when the user traverses
+        // over the elements inside of the same record
+        this._focusedItemResetTimeoutId = null;
+        this._focusedItem = null;
+      });
     }
   }
 

--- a/spine-expansion-panel-list.js
+++ b/spine-expansion-panel-list.js
@@ -168,6 +168,8 @@ class SpineFloatingExpansionList extends LitElement {
           padding: 8px 16px;
           cursor: pointer;
           transition: all 0.2s;
+          /* avoid displaying default focus outline */
+          outline: none;
   
           @apply --spine-expansion-panel-list-item;
           overflow: hidden;
@@ -186,11 +188,7 @@ class SpineFloatingExpansionList extends LitElement {
           @apply --spine-expansion-panel-list-expanded-item;
         }
         
-        #container ::slotted(.-spine-expansion-panel-list--item:focus) {
-          outline: none;
-        }
-        
-        #container ::slotted(.-spine-expansion-panel-list--item:not([expanded]):focus)::before {
+        #container ::slotted(.-spine-expansion-panel-list--item:not([expanded]).-sepl-focused-item)::before {
           content: '';
           background: var(---spine-epl-focus-color);
           position: absolute;
@@ -202,7 +200,7 @@ class SpineFloatingExpansionList extends LitElement {
           @apply --spine-expansion-panel-list-item-focus-bar;
         }
 
-        #container ::slotted(.-spine-expansion-panel-list--item:not([expanded]):focus)::after {
+        #container ::slotted(.-spine-expansion-panel-list--item:not([expanded]).-sepl-focused-item)::after {
           content: '';
           background: var(---spine-epl-focus-color);
           position: absolute;
@@ -239,7 +237,7 @@ class SpineFloatingExpansionList extends LitElement {
     }
     return html`${
         items.map(item => html`
-        <div class="-spine-expansion-panel-list--item"
+        <div class$="-spine-expansion-panel-list--item ${item === _focusedItem ? '-sepl-focused-item' : ''}"
              tabindex="0"
              expanded?="${(item === expandedItem)}"
              seplItem="${item}" 
@@ -466,7 +464,6 @@ class SpineFloatingExpansionList extends LitElement {
   }
 
   _handleAnyFocus(event) {
-    console.log('_handleAnyFocus');
     this._focusedItem = this._getItemByEvent(event);
   }
 

--- a/test/spine-expansion-panel-list_test.html
+++ b/test/spine-expansion-panel-list_test.html
@@ -40,48 +40,58 @@
   import {expansionToggleClassName} from '../spine-expansion-panel-list.js';
 
   class TestElementContainer extends LitElement {
-    constructor() {
-      super();
-      this.items = testItems;
+    static get properties() {
+      return {
+        /**
+         * An expression string that is evaluated dynamically (with `eval` function), which has to
+         * evaluate to lit-html `TemplateResult` instance that should be rendered
+         */
+        content: String
+      }
     }
+
     _render() {
-      return html`
-        <div id="list-container">
-          <spine-expansion-panel-list id="list"
-            items="${this.items}"
-
-            renderItem="${item => html`
-              <div class="collapsed-test-item">
-                <div>${item.name}</div>
-                <a href="${item.url}">GitHub page</a>
-              </div>
-            `}"
-
-            renderExpandedItem="${item => html`
-              <div class="expanded-test-item">
-                <h2 class$="${expansionToggleClassName}">
-                  <paper-card class="header-child-element">
-                    <p class="header-inner-element">
-                      ${item.name}
-                    </p>
-                  </paper-card>
-                </h2>
-                <a href="${item.url}">GitHub page</a>
-                <span class="not-an-expansion-toggle">regular content</span>
-              </div>
-            `}"
-
-          </spine-expansion-panel-list>
-        </div>
-      `;
+      return eval(this.content);
     }
   }
   window.customElements.define('test-element-container', TestElementContainer);
+
+  function renderTestSetup() {
+    return html`
+      <div id="list-container">
+        <spine-expansion-panel-list id="list"
+          items="${testItems}"
+
+          renderItem="${item => html`
+            <div class="collapsed-test-item">
+              <div>${item.name}</div>
+              <a href="${item.url}">GitHub page</a>
+            </div>
+          `}"
+
+          renderExpandedItem="${item => html`
+            <div class="expanded-test-item">
+              <h2 class$="${expansionToggleClassName}">
+                <paper-card class="header-child-element">
+                  <p class="header-inner-element">
+                    ${item.name}
+                  </p>
+                </paper-card>
+              </h2>
+              <a href="${item.url}">GitHub page</a>
+              <span class="not-an-expansion-toggle">regular content</span>
+            </div>
+          `}"
+
+        </spine-expansion-panel-list>
+      </div>
+    `;
+  }
 </script>
 
 <test-fixture id="test-setup">
   <template>
-    <test-element-container></test-element-container>
+    <test-element-container content="renderTestSetup()"></test-element-container>
   </template>
 </test-fixture>
 


### PR DESCRIPTION
Contains two improvements:
- The focused state of the record keeps preserved even in cases when some subelement of the record is focused (the record was previously highlighted as focused only when the main record's container was selected, but not when some of its contents were selected, such as menu buttons).
- The rendering functions now receive an additional `focused` parameter so to address scenarios like displaying a menu on a focused record.