### PR TITLE
 Support preserving original light DOM in `lightAndShadowDomRenderingMixin`

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "web-component",
     "polymer"
   ],
-  "version": "0.4.3",
+  "version": "0.4.4",
   "resolutions": {
     "inherits": "2.0.3",
     "samsam": "1.1.3",

--- a/spine-light-and-shadow-dom-rendering-mixin.js
+++ b/spine-light-and-shadow-dom-rendering-mixin.js
@@ -32,7 +32,7 @@ const lightAndShadowDomRenderingMixin =
        * @protected
        */
       _renderLightDOM() {
-        return html``;
+        return null;
       }
 
       /**

--- a/spine-light-and-shadow-dom-rendering-mixin.js
+++ b/spine-light-and-shadow-dom-rendering-mixin.js
@@ -13,7 +13,7 @@ import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
  * It adds a `_renderLightDOM`, which is similar to `_render` method, but renders content to
  * element's light DOM.
  *
- *  @mixinFunction
+ * @mixinFunction
  * @param {*} superClass a class to be mixed up with `lightAndShadowDomRenderingMixin`, expected to
  *                       extend the LitElement class directly or indirectly
  * @returns {*} a class definition that extends the provided `superClass` and has the
@@ -23,6 +23,11 @@ const lightAndShadowDomRenderingMixin =
     dedupingMixin(superClass => class extends superClass {
       /**
        * Similar to `_render`, but renders content that should be placed in an element's light DOM.
+       *
+       * Returning `null` or `undefined` retains the original light DOM content. Original DOM
+       * content can be preserved in this way only until it is overwritten by `_renderLightDOM`
+       * returning a non-null/non-undefined content at least once after element creation, after
+       * which returning `null` or `undefined` makes an empty content to be rendered instead.
        *
        * @protected
        */
@@ -38,8 +43,15 @@ const lightAndShadowDomRenderingMixin =
         super._applyRender(result, node);
 
         // render light DOM tree
-        const lightDOMTemplateResult = this._renderLightDOM();
-        render( lightDOMTemplateResult, this);
+        let lightDOMTemplateResult = this._renderLightDOM();
+        if (lightDOMTemplateResult != null ||
+            this.__lightAndShadowDomRenderingMixin_originalContentRewritten) {
+          if (lightDOMTemplateResult == null) {
+            lightDOMTemplateResult = html``;
+          }
+          render(lightDOMTemplateResult, this);
+          this.__lightAndShadowDomRenderingMixin_originalContentRewritten = true;
+        }
       }
     });
 export default lightAndShadowDomRenderingMixin;

--- a/spine-light-and-shadow-dom-rendering-mixin.js
+++ b/spine-light-and-shadow-dom-rendering-mixin.js
@@ -51,6 +51,9 @@ const lightAndShadowDomRenderingMixin = dedupingMixin(superClass => class extend
       }
       render(lightDOMTemplateResult, this);
       this.__lightAndShadowDomRenderingMixin_originalContentRewritten = true;
+    } else {
+      // preserve the light DOM that might have been originally placed into this component's subtree
+      // until `this._renderLightDOM()` returns a non-null/non-undefined template
     }
   }
 });

--- a/spine-light-and-shadow-dom-rendering-mixin.js
+++ b/spine-light-and-shadow-dom-rendering-mixin.js
@@ -54,4 +54,5 @@ const lightAndShadowDomRenderingMixin = dedupingMixin(superClass => class extend
     }
   }
 });
+
 export default lightAndShadowDomRenderingMixin;

--- a/spine-light-and-shadow-dom-rendering-mixin.js
+++ b/spine-light-and-shadow-dom-rendering-mixin.js
@@ -20,39 +20,38 @@ import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
  *              `lightAndShadowDomRenderingMixin` functionality, that should be extended by a class
  *              that needs to apply this mixin
  */
-const lightAndShadowDomRenderingMixin =
-    dedupingMixin(superClass => class extends superClass {
-      /**
-       * Similar to `_render`, but renders content that should be placed in an element's light DOM.
-       *
-       * Returning `null` or `undefined` retains the original light DOM content. Original DOM
-       * content can be preserved in this way only until it is overwritten by `_renderLightDOM`
-       * returning a non-null/non-undefined content at least once after element creation, after
-       * which returning `null` or `undefined` makes an empty content to be rendered instead.
-       *
-       * @protected
-       */
-      _renderLightDOM() {
-        return null;
-      }
+const lightAndShadowDomRenderingMixin = dedupingMixin(superClass => class extends superClass {
+  /**
+   * Similar to `_render`, but renders content that should be placed in an element's light DOM.
+   *
+   * Returning `null` or `undefined` retains the original light DOM content. Original DOM
+   * content can be preserved in this way only until it is overwritten by `_renderLightDOM`
+   * returning a non-null/non-undefined content at least once after element creation, after
+   * which returning `null` or `undefined` makes an empty content to be rendered instead.
+   *
+   * @protected
+   */
+  _renderLightDOM() {
+    return null;
+  }
 
-      /**
-       * @override
-       */
-      _applyRender(result, node) {
-        // render shadow DOM tree
-        super._applyRender(result, node);
+  /**
+   * @override
+   */
+  _applyRender(result, node) {
+    // render shadow DOM tree
+    super._applyRender(result, node);
 
-        // render light DOM tree
-        let lightDOMTemplateResult = this._renderLightDOM();
-        if (lightDOMTemplateResult != null ||
-            this.__lightAndShadowDomRenderingMixin_originalContentRewritten) {
-          if (lightDOMTemplateResult == null) {
-            lightDOMTemplateResult = html``;
-          }
-          render(lightDOMTemplateResult, this);
-          this.__lightAndShadowDomRenderingMixin_originalContentRewritten = true;
-        }
+    // render light DOM tree
+    let lightDOMTemplateResult = this._renderLightDOM();
+    if (lightDOMTemplateResult != null ||
+        this.__lightAndShadowDomRenderingMixin_originalContentRewritten) {
+      if (lightDOMTemplateResult == null) {
+        lightDOMTemplateResult = html``;
       }
-    });
+      render(lightDOMTemplateResult, this);
+      this.__lightAndShadowDomRenderingMixin_originalContentRewritten = true;
+    }
+  }
+});
 export default lightAndShadowDomRenderingMixin;


### PR DESCRIPTION
Returning `null` or `undefined` from `_renderLightDOM()` can now be used to retains the original light DOM content (it was always overwritten by this method previously).